### PR TITLE
SLING-4283: Support DeepInfra error responses

### DIFF
--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/Stream.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/extension/Stream.kt
@@ -1,5 +1,8 @@
 package com.aallam.openai.client.internal.extension
 
+import com.aallam.openai.api.exception.InvalidRequestException
+import com.aallam.openai.api.exception.OpenAIError
+import com.aallam.openai.api.exception.OpenAIErrorDetails
 import com.aallam.openai.client.internal.JsonLenient
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
@@ -7,6 +10,11 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.isActive
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 private const val STREAM_PREFIX = "data:"
 private const val STREAM_END_TOKEN = "$STREAM_PREFIX [DONE]"
@@ -21,7 +29,26 @@ internal suspend inline fun <reified T> FlowCollector<T>.streamEventsFrom(respon
             val line = channel.readUTF8Line() ?: continue
             val value: T = when {
                 line.startsWith(STREAM_END_TOKEN) -> break
-                line.startsWith(STREAM_PREFIX) -> JsonLenient.decodeFromString(line.removePrefix(STREAM_PREFIX))
+                line.startsWith(STREAM_PREFIX) -> {
+                    val jsonData = line.removePrefix(STREAM_PREFIX)
+                    try {
+                        JsonLenient.decodeFromString(jsonData)
+                    } catch (e: SerializationException) {
+                        val body = JsonLenient.decodeFromString<JsonObject>(jsonData)
+                        val errorMessageContent = body["error_message"]?.jsonPrimitive?.content
+                        if(errorMessageContent != null) {
+                            val errorMessageJsonStr = errorMessageContent.substring(errorMessageContent.indexOf("{"))
+                            val errorJson = errorMessageJsonStr.let { Json.parseToJsonElement(it) }
+                            val errorMsg = errorJson.jsonObject["message"]?.jsonPrimitive?.content
+                            if (errorMsg?.startsWith("This model's maximum context length is") == true) {
+                                throw InvalidRequestException(400, OpenAIError(detail =
+                                    OpenAIErrorDetails(message = errorMsg, code = "context_length_exceeded", param="messages", type = "invalid_request_error")
+                                ))
+                            }
+                        }
+                        throw e
+                    }
+                }
                 else -> continue
             }
             emit(value)

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
@@ -53,6 +53,7 @@ internal class HttpTransport(private val httpClient: HttpClient) : HttpRequester
         is ClientRequestException -> openAIAPIException(e)
         is ServerResponseException -> handleServerResponseException(e)
         is HttpRequestTimeoutException, is SocketTimeoutException, is ConnectTimeoutException -> OpenAITimeoutException(e)
+        is InvalidRequestException -> e
         is IOException -> GenericIOException(e)
         else -> OpenAIHttpException(e)
     }

--- a/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
+++ b/openai-client/src/commonMain/kotlin/com.aallam.openai.client/internal/http/HttpTransport.kt
@@ -10,6 +10,11 @@ import io.ktor.client.statement.*
 import io.ktor.util.reflect.*
 import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.lang.RuntimeException
 
 /** HTTP transport layer */
 internal class HttpTransport(private val httpClient: HttpClient) : HttpRequester {
@@ -46,10 +51,28 @@ internal class HttpTransport(private val httpClient: HttpClient) : HttpRequester
     private suspend fun handleException(e: Throwable) = when (e) {
         is CancellationException -> e // propagate coroutine cancellation
         is ClientRequestException -> openAIAPIException(e)
-        is ServerResponseException -> OpenAIServerException(e)
+        is ServerResponseException -> handleServerResponseException(e)
         is HttpRequestTimeoutException, is SocketTimeoutException, is ConnectTimeoutException -> OpenAITimeoutException(e)
         is IOException -> GenericIOException(e)
         else -> OpenAIHttpException(e)
+    }
+
+    private suspend fun handleServerResponseException(e: ServerResponseException): RuntimeException {
+        // DeepInfra API returns a 500 status code when the context length exceeds the maximum allowed length, while
+        // the openAI API returns a 400 status code. This is a workaround to handle the DeepInfra API response.
+        if(e.response.status.value == 500) {
+            val body = e.response.body<JsonObject>()
+            val errorContent = body["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content
+            val errorJson = errorContent?.let { Json.parseToJsonElement(it) }
+            val errorMsg = errorJson?.jsonObject?.get("message")?.jsonPrimitive?.content
+            if (errorMsg?.startsWith("This model's maximum context length is") == true) {
+                return InvalidRequestException(400, OpenAIError(detail =
+                    OpenAIErrorDetails(message = errorMsg, code = "context_length_exceeded", param="messages", type = "invalid_request_error")), e)
+            }
+            return OpenAIServerException(e)
+        } else {
+            return OpenAIServerException(e)
+        }
     }
 
     /**

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
@@ -43,6 +43,27 @@ class TestChatCompletions : TestOpenAI() {
     }
 
     @Test
+    fun testStreamingChatCompletionsExceedingTokenLimit() = test {
+        val request = chatCompletionRequest {
+            model = ModelId("gpt-3.5-turbo")
+            messages {
+                message {
+                    role = ChatRole.User
+                    content = SystemFileSystem.source(
+                        testFilePath("text/two_character_screenplay.txt")
+                    ).buffered().readString()
+                }
+            }
+        }
+
+        val result = runCatching {
+            openAI.chatCompletions(request).collect { }
+        }
+
+        assert(result.exceptionOrNull() is InvalidRequestException)
+    }
+
+    @Test
     fun chatCompletions() = test {
         val request = chatCompletionRequest {
             model = ModelId("gpt-3.5-turbo")

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestChatCompletions.kt
@@ -2,12 +2,17 @@ package com.aallam.openai.client
 
 import com.aallam.openai.api.chat.*
 import com.aallam.openai.api.chat.ChatResponseFormat.Companion.jsonSchema
+import com.aallam.openai.api.exception.InvalidRequestException
 import com.aallam.openai.api.model.ModelId
+import com.aallam.openai.client.internal.testFilePath
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.io.buffered
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -17,6 +22,25 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.*
 
 class TestChatCompletions : TestOpenAI() {
+
+    @Test
+    fun testChatCompletionExceedingTokenLimit() = test {
+        val request = chatCompletionRequest {
+            model = ModelId("gpt-3.5-turbo")
+            messages {
+                message {
+                    role = ChatRole.User
+                    content = SystemFileSystem.source(
+                        testFilePath("text/two_character_screenplay.txt")
+                    ).buffered().readString()
+                }
+            }
+        }
+
+        assertFailsWith<InvalidRequestException> {
+            openAI.chatCompletion(request)
+        }
+    }
 
     @Test
     fun chatCompletions() = test {

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepInfraOpenAICompatibleEndpoint.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepInfraOpenAICompatibleEndpoint.kt
@@ -30,7 +30,7 @@ private fun transport(config: OpenAIConfig? = null): HttpTransport {
 }
 
 abstract class TestDeepinfraOpenAICompatibleEndpoint {
-    internal val openAI = OpenAIApi(transport())
+    internal val deepInfra = OpenAIApi(transport())
 
     internal fun generateOpenAI(
         config: OpenAIConfig

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepInfraOpenAICompatibleEndpoint.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepInfraOpenAICompatibleEndpoint.kt
@@ -1,0 +1,42 @@
+package com.aallam.openai.client
+
+import com.aallam.openai.api.http.Timeout
+import com.aallam.openai.api.logging.LogLevel
+import com.aallam.openai.client.internal.OpenAIApi
+import com.aallam.openai.client.internal.createHttpClient
+import com.aallam.openai.client.internal.env
+import com.aallam.openai.client.internal.http.HttpTransport
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.minutes
+
+internal val deepInfraToken: String
+    get() = requireNotNull(env("DEEPINFRA_API_KEY")) { "DEEPINFRA_API_KEY environment variable must be set." }
+
+
+internal val deepinfraConfig: OpenAIConfig = OpenAIConfig(
+    token = deepInfraToken,
+    logging = LoggingConfig(logLevel = LogLevel.All),
+    timeout = Timeout(socket = 1.minutes),
+    host = OpenAIHost(baseUrl = "https://api.deepinfra.com/v1/openai/"),
+)
+
+private fun transport(config: OpenAIConfig? = null): HttpTransport {
+    return HttpTransport(
+        createHttpClient(
+            config ?: deepinfraConfig
+        )
+    )
+}
+
+abstract class TestDeepinfraOpenAICompatibleEndpoint {
+    internal val openAI = OpenAIApi(transport())
+
+    internal fun generateOpenAI(
+        config: OpenAIConfig
+    ): OpenAIApi {
+        return OpenAIApi(transport(config))
+    }
+
+    fun test(testBody: suspend TestScope.() -> Unit) = runTest(timeout = 1.minutes, testBody = testBody)
+}

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepinfraChatCompletions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepinfraChatCompletions.kt
@@ -1,10 +1,13 @@
 package com.aallam.openai.client
 
+import com.aallam.openai.api.chat.ChatCompletionChunk
 import com.aallam.openai.api.chat.ChatRole
 import com.aallam.openai.api.chat.chatCompletionRequest
 import com.aallam.openai.api.exception.InvalidRequestException
 import com.aallam.openai.api.model.ModelId
 import com.aallam.openai.client.internal.testFilePath
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.io.buffered
 import kotlinx.io.files.SystemFileSystem
 import kotlin.test.Test
@@ -28,7 +31,28 @@ class TestDeepinfraChatCompletions : TestDeepinfraOpenAICompatibleEndpoint() {
         }
 
         assertFailsWith<InvalidRequestException> {
-            openAI.chatCompletion(request)
+            deepInfra.chatCompletion(request)
         }
+    }
+
+    @Test
+    fun testStreamingChatCompletionsExceedingTokenLimit() = test {
+        val request = chatCompletionRequest {
+            model = ModelId("GuilhermeFreire/llama-3.3-70b-32k-instruct-slg-1-11-1-16k")
+            messages {
+                message {
+                    role = ChatRole.User
+                    content = SystemFileSystem.source(
+                        testFilePath("text/two_character_screenplay.txt")
+                    ).buffered().readString()
+                }
+            }
+        }
+
+        val result = runCatching {
+            deepInfra.chatCompletions(request).collect { }
+        }
+
+        assert(result.exceptionOrNull() is InvalidRequestException)
     }
 }

--- a/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepinfraChatCompletions.kt
+++ b/openai-client/src/commonTest/kotlin/com/aallam/openai/client/TestDeepinfraChatCompletions.kt
@@ -1,0 +1,34 @@
+package com.aallam.openai.client
+
+import com.aallam.openai.api.chat.ChatRole
+import com.aallam.openai.api.chat.chatCompletionRequest
+import com.aallam.openai.api.exception.InvalidRequestException
+import com.aallam.openai.api.model.ModelId
+import com.aallam.openai.client.internal.testFilePath
+import kotlinx.io.buffered
+import kotlinx.io.files.SystemFileSystem
+import kotlin.test.Test
+import kotlinx.io.readString
+import kotlin.test.assertFailsWith
+
+class TestDeepinfraChatCompletions : TestDeepinfraOpenAICompatibleEndpoint() {
+
+    @Test
+    fun testChatCompletionExceedingTokenLimit() = test {
+        val request = chatCompletionRequest {
+            model = ModelId("GuilhermeFreire/llama-3.3-70b-32k-instruct-slg-1-11-1-16k")
+            messages {
+                message {
+                    role = ChatRole.User
+                    content = SystemFileSystem.source(
+                        testFilePath("text/two_character_screenplay.txt")
+                    ).buffered().readString()
+                }
+            }
+        }
+
+        assertFailsWith<InvalidRequestException> {
+            openAI.chatCompletion(request)
+        }
+    }
+}

--- a/openai-client/src/commonTest/resources/text/two_character_screenplay.txt
+++ b/openai-client/src/commonTest/resources/text/two_character_screenplay.txt
@@ -1,0 +1,1399 @@
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: The sky looks different tonight.
+JORDAN: Always.
+ALEX: It's too late for regrets now.
+JORDAN: Then we make the best of it.
+JORDAN: Maybe control is just an illusion.
+ALEX: Do you ever think about what comes next?
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: What if this is all there is?
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: It's too late for regrets now.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: I can't believe we made it this far.
+JORDAN: You always were the dreamer.
+JORDAN: It's too late for regrets now.
+JORDAN: What if this is all there is?
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: We should have left when we had the chance.
+ALEX: And you were always the realist.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: I can't believe we made it this far.
+JORDAN: Then we make the best of it.
+JORDAN: Always.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: Do you ever think about what comes next?
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: What if this is all there is?
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: What if this is all there is?
+ALEX: You're always so calm. How do you do it?
+ALEX: You're always so calm. How do you do it?
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: You always were the dreamer.
+ALEX: And you were always the realist.
+ALEX: One last time. Are you with me?
+ALEX: What if this is all there is?
+ALEX: I can't believe we made it this far.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: I just pretend I'm in control.
+JORDAN: One last time. Are you with me?
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: I can't believe we made it this far.
+ALEX: I can't believe we made it this far.
+ALEX: You always were the dreamer.
+JORDAN: One last time. Are you with me?
+ALEX: Then we make the best of it.
+ALEX: We should have left when we had the chance.
+ALEX: You always were the dreamer.
+JORDAN: What if this is all there is?
+ALEX: What if this is all there is?
+JORDAN: I can't believe we made it this far.
+JORDAN: Always.
+ALEX: The sky looks different tonight.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: And you were always the realist.
+JORDAN: It's too late for regrets now.
+JORDAN: We should have left when we had the chance.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: The sky looks different tonight.
+JORDAN: And you were always the realist.
+JORDAN: And you were always the realist.
+JORDAN: Do you ever think about what comes next?
+ALEX: One last time. Are you with me?
+JORDAN: It's too late for regrets now.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: I just pretend I'm in control.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: One last time. Are you with me?
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: You're always so calm. How do you do it?
+ALEX: I can't believe we made it this far.
+JORDAN: And you were always the realist.
+ALEX: You always were the dreamer.
+ALEX: Then we make the best of it.
+JORDAN: The sky looks different tonight.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: One last time. Are you with me?
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: It's too late for regrets now.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: What if this is all there is?
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: What if this is all there is?
+JORDAN: I can't believe we made it this far.
+JORDAN: Do you ever think about what comes next?
+JORDAN: One last time. Are you with me?
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: It's too late for regrets now.
+ALEX: It's too late for regrets now.
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: You're always so calm. How do you do it?
+JORDAN: You're always so calm. How do you do it?
+JORDAN: What if this is all there is?
+JORDAN: Always.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: And you were always the realist.
+ALEX: You always were the dreamer.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: And you were always the realist.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Then we make the best of it.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Always.
+ALEX: One last time. Are you with me?
+ALEX: I just pretend I'm in control.
+JORDAN: One last time. Are you with me?
+JORDAN: Always.
+JORDAN: You're always so calm. How do you do it?
+ALEX: It's too late for regrets now.
+JORDAN: Then we make the best of it.
+ALEX: We should have left when we had the chance.
+ALEX: I can't believe we made it this far.
+JORDAN: One last time. Are you with me?
+JORDAN: And you were always the realist.
+ALEX: Then we make the best of it.
+JORDAN: You always were the dreamer.
+JORDAN: The sky looks different tonight.
+ALEX: Then we make the best of it.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: And you were always the realist.
+ALEX: Maybe control is just an illusion.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: We should have left when we had the chance.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: It's too late for regrets now.
+JORDAN: I just pretend I'm in control.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: What if this is all there is?
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: The sky looks different tonight.
+JORDAN: Always.
+JORDAN: I just pretend I'm in control.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Always.
+JORDAN: Do you ever think about what comes next?
+JORDAN: And you were always the realist.
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: And you were always the realist.
+ALEX: You're always so calm. How do you do it?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: We should have left when we had the chance.
+JORDAN: You always were the dreamer.
+ALEX: I just pretend I'm in control.
+ALEX: And you were always the realist.
+JORDAN: I can't believe we made it this far.
+ALEX: We should have left when we had the chance.
+ALEX: I can't believe we made it this far.
+ALEX: I can't believe we made it this far.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: It's too late for regrets now.
+ALEX: The sky looks different tonight.
+JORDAN: I just pretend I'm in control.
+ALEX: Maybe control is just an illusion.
+ALEX: I can't believe we made it this far.
+JORDAN: What if this is all there is?
+JORDAN: And you were always the realist.
+JORDAN: The sky looks different tonight.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: You're always so calm. How do you do it?
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: The sky looks different tonight.
+ALEX: What if this is all there is?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: We should have left when we had the chance.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Do you ever think about what comes next?
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: One last time. Are you with me?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe control is just an illusion.
+JORDAN: You always were the dreamer.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: What if this is all there is?
+JORDAN: Then we make the best of it.
+JORDAN: Always.
+ALEX: I can't believe we made it this far.
+ALEX: Do you ever think about what comes next?
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: It's too late for regrets now.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: One last time. Are you with me?
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: Maybe control is just an illusion.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: I just pretend I'm in control.
+JORDAN: Do you ever think about what comes next?
+JORDAN: I can't believe we made it this far.
+ALEX: Maybe control is just an illusion.
+JORDAN: Maybe control is just an illusion.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: What if this is all there is?
+JORDAN: I can't believe we made it this far.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: You always were the dreamer.
+ALEX: I can't believe we made it this far.
+JORDAN: Do you ever think about what comes next?
+ALEX: You always were the dreamer.
+ALEX: One last time. Are you with me?
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: I can't believe we made it this far.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Maybe control is just an illusion.
+JORDAN: Always.
+ALEX: You always were the dreamer.
+JORDAN: What if this is all there is?
+ALEX: The sky looks different tonight.
+ALEX: Do you ever think about what comes next?
+JORDAN: One last time. Are you with me?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: One last time. Are you with me?
+JORDAN: And you were always the realist.
+JORDAN: I just pretend I'm in control.
+JORDAN: You always were the dreamer.
+JORDAN: Do you ever think about what comes next?
+JORDAN: What if this is all there is?
+JORDAN: The sky looks different tonight.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Maybe control is just an illusion.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: I can't believe we made it this far.
+ALEX: Then we make the best of it.
+ALEX: I just pretend I'm in control.
+JORDAN: It's too late for regrets now.
+JORDAN: And you were always the realist.
+JORDAN: Maybe control is just an illusion.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Do you ever think about what comes next?
+ALEX: Always.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: The sky looks different tonight.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Maybe control is just an illusion.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: Maybe control is just an illusion.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: You always were the dreamer.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: What if this is all there is?
+ALEX: You're always so calm. How do you do it?
+ALEX: I just pretend I'm in control.
+ALEX: You're always so calm. How do you do it?
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Do you ever think about what comes next?
+JORDAN: Always.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: You're always so calm. How do you do it?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: You always were the dreamer.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: And you were always the realist.
+ALEX: Then we make the best of it.
+JORDAN: What if this is all there is?
+ALEX: The sky looks different tonight.
+ALEX: Do you ever think about what comes next?
+JORDAN: I can't believe we made it this far.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: What if this is all there is?
+JORDAN: Then we make the best of it.
+ALEX: The sky looks different tonight.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: I just pretend I'm in control.
+ALEX: I can't believe we made it this far.
+ALEX: Do you ever think about what comes next?
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: I can't believe we made it this far.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: You always were the dreamer.
+JORDAN: The sky looks different tonight.
+ALEX: Do you ever think about what comes next?
+ALEX: I just pretend I'm in control.
+JORDAN: Then we make the best of it.
+JORDAN: It's too late for regrets now.
+ALEX: One last time. Are you with me?
+ALEX: It's too late for regrets now.
+JORDAN: And you were always the realist.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: What if this is all there is?
+JORDAN: One last time. Are you with me?
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: I can't believe we made it this far.
+JORDAN: I just pretend I'm in control.
+ALEX: You're always so calm. How do you do it?
+JORDAN: I can't believe we made it this far.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Do you ever think about what comes next?
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: I just pretend I'm in control.
+JORDAN: What if this is all there is?
+JORDAN: And you were always the realist.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Do you ever think about what comes next?
+JORDAN: The sky looks different tonight.
+JORDAN: I can't believe we made it this far.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: We should have left when we had the chance.
+ALEX: It's too late for regrets now.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: And you were always the realist.
+ALEX: One last time. Are you with me?
+ALEX: And you were always the realist.
+JORDAN: What if this is all there is?
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: You're always so calm. How do you do it?
+JORDAN: What if this is all there is?
+ALEX: And you were always the realist.
+JORDAN: Then we make the best of it.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: You're always so calm. How do you do it?
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: I just pretend I'm in control.
+JORDAN: And you were always the realist.
+ALEX: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+ALEX: And you were always the realist.
+JORDAN: We should have left when we had the chance.
+ALEX: The sky looks different tonight.
+JORDAN: Maybe control is just an illusion.
+ALEX: Maybe control is just an illusion.
+ALEX: Maybe control is just an illusion.
+ALEX: We should have left when we had the chance.
+JORDAN: I just pretend I'm in control.
+ALEX: It's too late for regrets now.
+JORDAN: The sky looks different tonight.
+ALEX: I can't believe we made it this far.
+ALEX: What if this is all there is?
+ALEX: You're always so calm. How do you do it?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: One last time. Are you with me?
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: We should have left when we had the chance.
+ALEX: And you were always the realist.
+ALEX: What if this is all there is?
+ALEX: Do you ever think about what comes next?
+ALEX: You always were the dreamer.
+ALEX: You always were the dreamer.
+ALEX: The sky looks different tonight.
+JORDAN: I just pretend I'm in control.
+JORDAN: Always.
+JORDAN: I can't believe we made it this far.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: And you were always the realist.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: What if this is all there is?
+JORDAN: One last time. Are you with me?
+ALEX: Then we make the best of it.
+ALEX: One last time. Are you with me?
+JORDAN: What if this is all there is?
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: Then we make the best of it.
+ALEX: Maybe control is just an illusion.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: It's too late for regrets now.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Do you ever think about what comes next?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: It's too late for regrets now.
+ALEX: You're always so calm. How do you do it?
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: It's too late for regrets now.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: And you were always the realist.
+JORDAN: What if this is all there is?
+ALEX: Then we make the best of it.
+ALEX: I just pretend I'm in control.
+ALEX: The sky looks different tonight.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: It's too late for regrets now.
+ALEX: Maybe control is just an illusion.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: Maybe control is just an illusion.
+ALEX: Then we make the best of it.
+ALEX: I just pretend I'm in control.
+ALEX: The sky looks different tonight.
+JORDAN: Then we make the best of it.
+JORDAN: Always.
+ALEX: Then we make the best of it.
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Do you ever think about what comes next?
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: One last time. Are you with me?
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: You always were the dreamer.
+ALEX: I can't believe we made it this far.
+JORDAN: You always were the dreamer.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: And you were always the realist.
+ALEX: Do you ever think about what comes next?
+JORDAN: You're always so calm. How do you do it?
+ALEX: You always were the dreamer.
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: The sky looks different tonight.
+ALEX: Maybe control is just an illusion.
+ALEX: Then we make the best of it.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: Maybe control is just an illusion.
+JORDAN: Maybe control is just an illusion.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: The sky looks different tonight.
+JORDAN: One last time. Are you with me?
+ALEX: Maybe control is just an illusion.
+ALEX: What if this is all there is?
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: What if this is all there is?
+ALEX: The sky looks different tonight.
+JORDAN: You always were the dreamer.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: I can't believe we made it this far.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Then we make the best of it.
+ALEX: What if this is all there is?
+JORDAN: What if this is all there is?
+JORDAN: Always.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: I just pretend I'm in control.
+ALEX: One last time. Are you with me?
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Always.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Maybe control is just an illusion.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: It's too late for regrets now.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: The sky looks different tonight.
+JORDAN: Always.
+JORDAN: Then we make the best of it.
+JORDAN: Maybe control is just an illusion.
+JORDAN: The sky looks different tonight.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: Always.
+JORDAN: Then we make the best of it.
+JORDAN: Maybe control is just an illusion.
+JORDAN: What if this is all there is?
+JORDAN: The sky looks different tonight.
+ALEX: Then we make the best of it.
+ALEX: Then we make the best of it.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: One last time. Are you with me?
+ALEX: I can't believe we made it this far.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: You always were the dreamer.
+ALEX: We should have left when we had the chance.
+ALEX: You're always so calm. How do you do it?
+ALEX: Do you ever think about what comes next?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: You always were the dreamer.
+JORDAN: And you were always the realist.
+JORDAN: It's too late for regrets now.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: And you were always the realist.
+JORDAN: Then we make the best of it.
+ALEX: And you were always the realist.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: Do you ever think about what comes next?
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: You always were the dreamer.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Maybe control is just an illusion.
+JORDAN: What if this is all there is?
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Then we make the best of it.
+JORDAN: It's too late for regrets now.
+ALEX: I just pretend I'm in control.
+ALEX: Always.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: It's too late for regrets now.
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Then we make the best of it.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: What if this is all there is?
+JORDAN: I can't believe we made it this far.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: And you were always the realist.
+ALEX: We should have left when we had the chance.
+JORDAN: The sky looks different tonight.
+JORDAN: One last time. Are you with me?
+ALEX: Do you ever think about what comes next?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: You're always so calm. How do you do it?
+JORDAN: I just pretend I'm in control.
+ALEX: And you were always the realist.
+ALEX: What if this is all there is?
+ALEX: One last time. Are you with me?
+JORDAN: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+ALEX: We should have left when we had the chance.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: You always were the dreamer.
+ALEX: Always.
+ALEX: And you were always the realist.
+ALEX: The sky looks different tonight.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: Always.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Do you ever think about what comes next?
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: What if this is all there is?
+ALEX: Do you ever think about what comes next?
+JORDAN: The sky looks different tonight.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: I can't believe we made it this far.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: We should have left when we had the chance.
+JORDAN: What if this is all there is?
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: One last time. Are you with me?
+ALEX: Maybe control is just an illusion.
+ALEX: You always were the dreamer.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: What if this is all there is?
+JORDAN: The sky looks different tonight.
+JORDAN: One last time. Are you with me?
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: You always were the dreamer.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: The sky looks different tonight.
+JORDAN: One last time. Are you with me?
+ALEX: And you were always the realist.
+JORDAN: You always were the dreamer.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Then we make the best of it.
+ALEX: Maybe control is just an illusion.
+ALEX: You're always so calm. How do you do it?
+JORDAN: Always.
+ALEX: You always were the dreamer.
+ALEX: Maybe control is just an illusion.
+JORDAN: It's too late for regrets now.
+JORDAN: What if this is all there is?
+JORDAN: One last time. Are you with me?
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: You're always so calm. How do you do it?
+JORDAN: What if this is all there is?
+JORDAN: Maybe control is just an illusion.
+ALEX: We should have left when we had the chance.
+JORDAN: I just pretend I'm in control.
+ALEX: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+ALEX: It's too late for regrets now.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: I just pretend I'm in control.
+ALEX: I can't believe we made it this far.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: And you were always the realist.
+JORDAN: Do you ever think about what comes next?
+ALEX: I just pretend I'm in control.
+ALEX: You always were the dreamer.
+JORDAN: Always.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: The sky looks different tonight.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: One last time. Are you with me?
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: One last time. Are you with me?
+ALEX: We should have left when we had the chance.
+JORDAN: We should have left when we had the chance.
+JORDAN: The sky looks different tonight.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: One last time. Are you with me?
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: We should have left when we had the chance.
+JORDAN: Do you ever think about what comes next?
+ALEX: You're always so calm. How do you do it?
+ALEX: I can't believe we made it this far.
+ALEX: Do you ever think about what comes next?
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: What if this is all there is?
+ALEX: It's too late for regrets now.
+ALEX: I just pretend I'm in control.
+JORDAN: I just pretend I'm in control.
+ALEX: What if this is all there is?
+ALEX: What if this is all there is?
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: I just pretend I'm in control.
+JORDAN: What if this is all there is?
+JORDAN: It's too late for regrets now.
+ALEX: The sky looks different tonight.
+ALEX: It's too late for regrets now.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: I can't believe we made it this far.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Maybe control is just an illusion.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: One last time. Are you with me?
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: You're always so calm. How do you do it?
+ALEX: It's too late for regrets now.
+ALEX: Maybe control is just an illusion.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: You always were the dreamer.
+JORDAN: One last time. Are you with me?
+JORDAN: Then we make the best of it.
+ALEX: Always.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: I can't believe we made it this far.
+JORDAN: Then we make the best of it.
+JORDAN: What if this is all there is?
+JORDAN: And you were always the realist.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Do you ever think about what comes next?
+ALEX: I can't believe we made it this far.
+ALEX: Do you ever think about what comes next?
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: We should have left when we had the chance.
+ALEX: And you were always the realist.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: We should have left when we had the chance.
+JORDAN: I can't believe we made it this far.
+ALEX: The sky looks different tonight.
+ALEX: What if this is all there is?
+JORDAN: I can't believe we made it this far.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: One last time. Are you with me?
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: You're always so calm. How do you do it?
+ALEX: Do you ever think about what comes next?
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: I just pretend I'm in control.
+JORDAN: Always.
+JORDAN: The sky looks different tonight.
+JORDAN: Then we make the best of it.
+JORDAN: I can't believe we made it this far.
+JORDAN: I just pretend I'm in control.
+ALEX: The sky looks different tonight.
+JORDAN: We should have left when we had the chance.
+ALEX: What if this is all there is?
+JORDAN: It's too late for regrets now.
+ALEX: You always were the dreamer.
+JORDAN: It's too late for regrets now.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: You always were the dreamer.
+ALEX: You always were the dreamer.
+ALEX: I just pretend I'm in control.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Then we make the best of it.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: Always.
+JORDAN: It's too late for regrets now.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: We should have left when we had the chance.
+ALEX: And you were always the realist.
+JORDAN: You always were the dreamer.
+JORDAN: You always were the dreamer.
+ALEX: Do you ever think about what comes next?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: One last time. Are you with me?
+JORDAN: I can't believe we made it this far.
+JORDAN: We should have left when we had the chance.
+JORDAN: I can't believe we made it this far.
+ALEX: Do you ever think about what comes next?
+JORDAN: Then we make the best of it.
+ALEX: We should have left when we had the chance.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: What if this is all there is?
+JORDAN: We should have left when we had the chance.
+JORDAN: You're always so calm. How do you do it?
+ALEX: Then we make the best of it.
+ALEX: Maybe control is just an illusion.
+ALEX: Maybe control is just an illusion.
+JORDAN: I just pretend I'm in control.
+JORDAN: One last time. Are you with me?
+JORDAN: The sky looks different tonight.
+ALEX: I just pretend I'm in control.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: What if this is all there is?
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: It's too late for regrets now.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Always.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: I just pretend I'm in control.
+JORDAN: It's too late for regrets now.
+JORDAN: Then we make the best of it.
+JORDAN: Do you ever think about what comes next?
+JORDAN: And you were always the realist.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: You're always so calm. How do you do it?
+ALEX: I can't believe we made it this far.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: We should have left when we had the chance.
+JORDAN: One last time. Are you with me?
+JORDAN: Always.
+ALEX: You always were the dreamer.
+ALEX: The sky looks different tonight.
+ALEX: I just pretend I'm in control.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: We should have left when we had the chance.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: And you were always the realist.
+JORDAN: I just pretend I'm in control.
+ALEX: I just pretend I'm in control.
+JORDAN: We should have left when we had the chance.
+JORDAN: We should have left when we had the chance.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: We should have left when we had the chance.
+ALEX: Maybe control is just an illusion.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: The sky looks different tonight.
+JORDAN: One last time. Are you with me?
+JORDAN: Do you ever think about what comes next?
+ALEX: Then we make the best of it.
+ALEX: Then we make the best of it.
+JORDAN: The sky looks different tonight.
+JORDAN: I just pretend I'm in control.
+JORDAN: I can't believe we made it this far.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: You always were the dreamer.
+ALEX: I just pretend I'm in control.
+ALEX: Do you ever think about what comes next?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: I can't believe we made it this far.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: I can't believe we made it this far.
+JORDAN: You always were the dreamer.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: Always.
+ALEX: And you were always the realist.
+JORDAN: I just pretend I'm in control.
+JORDAN: Always.
+ALEX: You're always so calm. How do you do it?
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: Maybe control is just an illusion.
+ALEX: Always.
+JORDAN: One last time. Are you with me?
+ALEX: I can't believe we made it this far.
+ALEX: I can't believe we made it this far.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Do you ever think about what comes next?
+ALEX: Do you ever think about what comes next?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: One last time. Are you with me?
+ALEX: And you were always the realist.
+ALEX: The sky looks different tonight.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: We should have left when we had the chance.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: It's too late for regrets now.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: One last time. Are you with me?
+JORDAN: Maybe control is just an illusion.
+ALEX: We should have left when we had the chance.
+JORDAN: Do you ever think about what comes next?
+JORDAN: Do you hear that? The wind, it's calling us.
+JORDAN: We should have left when we had the chance.
+ALEX: I just pretend I'm in control.
+ALEX: You always were the dreamer.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: It's too late for regrets now.
+JORDAN: Maybe control is just an illusion.
+JORDAN: And you were always the realist.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: I can't believe we made it this far.
+ALEX: I can't believe we made it this far.
+ALEX: You're always so calm. How do you do it?
+ALEX: And you were always the realist.
+ALEX: One last time. Are you with me?
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: What if this is all there is?
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: We should have left when we had the chance.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: You're always so calm. How do you do it?
+ALEX: It's too late for regrets now.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: You always were the dreamer.
+JORDAN: Maybe control is just an illusion.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: You always were the dreamer.
+ALEX: I can't believe we made it this far.
+JORDAN: You're always so calm. How do you do it?
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Then we make the best of it.
+JORDAN: Then we make the best of it.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: One last time. Are you with me?
+JORDAN: I can't believe we made it this far.
+JORDAN: One last time. Are you with me?
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Then we make the best of it.
+ALEX: And you were always the realist.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: One last time. Are you with me?
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: One last time. Are you with me?
+ALEX: The sky looks different tonight.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: And you were always the realist.
+JORDAN: Maybe control is just an illusion.
+ALEX: And you were always the realist.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: I just pretend I'm in control.
+ALEX: You're always so calm. How do you do it?
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Always.
+JORDAN: Maybe control is just an illusion.
+JORDAN: You always were the dreamer.
+ALEX: Always.
+JORDAN: What if this is all there is?
+JORDAN: You always were the dreamer.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: I just pretend I'm in control.
+ALEX: You always were the dreamer.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: You always were the dreamer.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: What if this is all there is?
+ALEX: And you were always the realist.
+JORDAN: One last time. Are you with me?
+JORDAN: Do you ever think about what comes next?
+ALEX: And you were always the realist.
+JORDAN: You always were the dreamer.
+ALEX: Do you ever think about what comes next?
+JORDAN: Maybe control is just an illusion.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: The sky looks different tonight.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: I can't believe we made it this far.
+ALEX: Maybe control is just an illusion.
+JORDAN: One last time. Are you with me?
+ALEX: You're always so calm. How do you do it?
+JORDAN: You always were the dreamer.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: We should have left when we had the chance.
+ALEX: You're always so calm. How do you do it?
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: What if this is all there is?
+ALEX: Always.
+ALEX: And you were always the realist.
+JORDAN: And you were always the realist.
+ALEX: Then we make the best of it.
+JORDAN: Then we make the best of it.
+JORDAN: I just pretend I'm in control.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: And you were always the realist.
+ALEX: It's too late for regrets now.
+JORDAN: We should have left when we had the chance.
+ALEX: Always.
+JORDAN: You always were the dreamer.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: You're always so calm. How do you do it?
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: And you were always the realist.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: The sky looks different tonight.
+ALEX: I just pretend I'm in control.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Always.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Always.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Maybe control is just an illusion.
+JORDAN: The sky looks different tonight.
+JORDAN: I just pretend I'm in control.
+JORDAN: We should have left when we had the chance.
+JORDAN: What if this is all there is?
+ALEX: Always.
+JORDAN: I just pretend I'm in control.
+ALEX: What if this is all there is?
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Always.
+JORDAN: Maybe control is just an illusion.
+ALEX: What if this is all there is?
+ALEX: It's too late for regrets now.
+ALEX: Maybe control is just an illusion.
+JORDAN: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Maybe control is just an illusion.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: Maybe control is just an illusion.
+ALEX: Always.
+JORDAN: Maybe control is just an illusion.
+JORDAN: We should have left when we had the chance.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: And you were always the realist.
+JORDAN: Do you ever think about what comes next?
+ALEX: You always were the dreamer.
+JORDAN: One last time. Are you with me?
+ALEX: We should have left when we had the chance.
+JORDAN: One last time. Are you with me?
+JORDAN: Then we make the best of it.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: I just pretend I'm in control.
+JORDAN: Then we make the best of it.
+JORDAN: We should have left when we had the chance.
+ALEX: We should have left when we had the chance.
+ALEX: We should have left when we had the chance.
+JORDAN: What if this is all there is?
+ALEX: I can't believe we made it this far.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: What if this is all there is?
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: The sky looks different tonight.
+ALEX: I can't believe we made it this far.
+JORDAN: It's too late for regrets now.
+JORDAN: It's too late for regrets now.
+ALEX: Do you ever think about what comes next?
+ALEX: What if this is all there is?
+ALEX: It's too late for regrets now.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: We should have left when we had the chance.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: Do you ever think about what comes next?
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: You're always so calm. How do you do it?
+JORDAN: Maybe control is just an illusion.
+JORDAN: We should have left when we had the chance.
+ALEX: I just pretend I'm in control.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: And you were always the realist.
+JORDAN: Do you ever think about what comes next?
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: The sky looks different tonight.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Maybe control is just an illusion.
+JORDAN: It's too late for regrets now.
+JORDAN: And you were always the realist.
+JORDAN: One last time. Are you with me?
+JORDAN: Do you ever think about what comes next?
+ALEX: You're always so calm. How do you do it?
+ALEX: Maybe control is just an illusion.
+ALEX: You always were the dreamer.
+ALEX: You're always so calm. How do you do it?
+JORDAN: Maybe control is just an illusion.
+JORDAN: Always.
+JORDAN: You're always so calm. How do you do it?
+ALEX: You always were the dreamer.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: Then we make the best of it.
+ALEX: Always.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: The sky looks different tonight.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: I just pretend I'm in control.
+ALEX: You always were the dreamer.
+ALEX: We should have left when we had the chance.
+ALEX: Always.
+JORDAN: Maybe control is just an illusion.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: We should have left when we had the chance.
+ALEX: The sky looks different tonight.
+ALEX: We should have left when we had the chance.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Always.
+ALEX: Do you ever think about what comes next?
+JORDAN: Always.
+ALEX: What if this is all there is?
+ALEX: Then we make the best of it.
+JORDAN: One last time. Are you with me?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: I just pretend I'm in control.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: And you were always the realist.
+JORDAN: I just pretend I'm in control.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: The sky looks different tonight.
+ALEX: Do you ever think about what comes next?
+ALEX: You always were the dreamer.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: I just pretend I'm in control.
+JORDAN: What if this is all there is?
+ALEX: Then we make the best of it.
+ALEX: And you were always the realist.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: What if this is all there is?
+JORDAN: And you were always the realist.
+ALEX: The sky looks different tonight.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: The sky looks different tonight.
+JORDAN: You're always so calm. How do you do it?
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: It's too late for regrets now.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: What if this is all there is?
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: Always.
+ALEX: One last time. Are you with me?
+ALEX: The sky looks different tonight.
+ALEX: Do you ever think about what comes next?
+ALEX: Do you ever think about what comes next?
+JORDAN: We should have left when we had the chance.
+JORDAN: Maybe control is just an illusion.
+JORDAN: And you were always the realist.
+ALEX: What if this is all there is?
+JORDAN: It's too late for regrets now.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: And you were always the realist.
+ALEX: Then we make the best of it.
+ALEX: Always.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: Always.
+JORDAN: One last time. Are you with me?
+ALEX: One last time. Are you with me?
+ALEX: One last time. Are you with me?
+JORDAN: Maybe control is just an illusion.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: It's too late for regrets now.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: You're always so calm. How do you do it?
+JORDAN: It's too late for regrets now.
+ALEX: It's too late for regrets now.
+ALEX: The sky looks different tonight.
+ALEX: We should have left when we had the chance.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Then we make the best of it.
+ALEX: It's too late for regrets now.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: The sky looks different tonight.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: I can't believe we made it this far.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: You're always so calm. How do you do it?
+ALEX: And you were always the realist.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: Maybe control is just an illusion.
+JORDAN: Do you ever think about what comes next?
+ALEX: You're always so calm. How do you do it?
+ALEX: The sky looks different tonight.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: It's too late for regrets now.
+ALEX: You always were the dreamer.
+JORDAN: We should have left when we had the chance.
+ALEX: You're always so calm. How do you do it?
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: What if this is all there is?
+JORDAN: It's too late for regrets now.
+JORDAN: What if this is all there is?
+ALEX: You're always so calm. How do you do it?
+JORDAN: Always.
+ALEX: What if this is all there is?
+JORDAN: It's too late for regrets now.
+ALEX: There's something in the air, a tension we can't ignore.
+ALEX: Maybe control is just an illusion.
+JORDAN: You always were the dreamer.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: Always.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: One last time. Are you with me?
+ALEX: If we don't find a way out, this might be the end.
+ALEX: It's too late for regrets now.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: You always were the dreamer.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: Do you ever think about what comes next?
+ALEX: Maybe control is just an illusion.
+ALEX: You're always so calm. How do you do it?
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Do you ever think about what comes next?
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: I can't believe we made it this far.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Always.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: What if this is all there is?
+JORDAN: Always.
+ALEX: And you were always the realist.
+ALEX: I just pretend I'm in control.
+JORDAN: What if this is all there is?
+ALEX: It's too late for regrets now.
+JORDAN: I just pretend I'm in control.
+ALEX: Then we make the best of it.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: You always were the dreamer.
+ALEX: One last time. Are you with me?
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: One last time. Are you with me?
+ALEX: You always were the dreamer.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: The sky looks different tonight.
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: Maybe control is just an illusion.
+JORDAN: And you were always the realist.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: We should have left when we had the chance.
+JORDAN: Always.
+ALEX: Then we make the best of it.
+ALEX: You're always so calm. How do you do it?
+JORDAN: You always were the dreamer.
+JORDAN: I just pretend I'm in control.
+ALEX: Always.
+ALEX: You're always so calm. How do you do it?
+JORDAN: Maybe control is just an illusion.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Do you ever think about what comes next?
+JORDAN: You always were the dreamer.
+JORDAN: I just pretend I'm in control.
+ALEX: Always.
+ALEX: And you were always the realist.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Then we make the best of it.
+ALEX: I just pretend I'm in control.
+JORDAN: Maybe control is just an illusion.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: Always.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: I just pretend I'm in control.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: I just pretend I'm in control.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: And you were always the realist.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: I just pretend I'm in control.
+JORDAN: What if this is all there is?
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: One last time. Are you with me?
+ALEX: One last time. Are you with me?
+ALEX: We should have left when we had the chance.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: And you were always the realist.
+ALEX: You're always so calm. How do you do it?
+JORDAN: You always were the dreamer.
+JORDAN: You always were the dreamer.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: I just pretend I'm in control.
+JORDAN: Then we make the best of it.
+ALEX: It's too late for regrets now.
+ALEX: And you were always the realist.
+JORDAN: One last time. Are you with me?
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Then we make the best of it.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: And you were always the realist.
+ALEX: It's too late for regrets now.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: The sky looks different tonight.
+ALEX: The sky looks different tonight.
+JORDAN: Do you ever think about what comes next?
+ALEX: You always were the dreamer.
+JORDAN: And you were always the realist.
+JORDAN: I just pretend I'm in control.
+JORDAN: I can't believe we made it this far.
+JORDAN: Do you ever think about what comes next?
+JORDAN: I can't believe we made it this far.
+ALEX: You're always so calm. How do you do it?
+ALEX: What if this is all there is?
+ALEX: You always were the dreamer.
+ALEX: You're always so calm. How do you do it?
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: We should have left when we had the chance.
+JORDAN: Then we make the best of it.
+ALEX: You always were the dreamer.
+JORDAN: And you were always the realist.
+JORDAN: Do you ever think about what comes next?
+JORDAN: It's too late for regrets now.
+JORDAN: I just pretend I'm in control.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: Then let's make sure the end is worth remembering.
+ALEX: What if this is all there is?
+ALEX: And you were always the realist.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: I just pretend I'm in control.
+JORDAN: Do you ever think about what comes next?
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: You always were the dreamer.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: One last time. Are you with me?
+JORDAN: It's too late for regrets now.
+JORDAN: It's too late for regrets now.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Then we make the best of it.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: It's too late for regrets now.
+JORDAN: What if this is all there is?
+JORDAN: I can't believe we made it this far.
+ALEX: Then we make the best of it.
+JORDAN: Do you ever think about what comes next?
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: We should have left when we had the chance.
+JORDAN: It's too late for regrets now.
+JORDAN: Do you hear that? The wind, it's calling us.
+ALEX: I just pretend I'm in control.
+JORDAN: And you were always the realist.
+JORDAN: Maybe control is just an illusion.
+ALEX: I can't believe we made it this far.
+JORDAN: Then let's make sure the end is worth remembering.
+JORDAN: The sky looks different tonight.
+JORDAN: Then we make the best of it.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: I just pretend I'm in control.
+ALEX: What if this is all there is?
+JORDAN: Maybe. But it's an illusion we need to survive.
+ALEX: Then let's make sure the end is worth remembering.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: Do you ever think about what comes next?
+JORDAN: You always were the dreamer.
+JORDAN: I just pretend I'm in control.
+ALEX: Always.
+JORDAN: Always.
+ALEX: I just pretend I'm in control.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: Then we make the best of it.
+ALEX: You're always so calm. How do you do it?
+JORDAN: You're always so calm. How do you do it?
+JORDAN: I can't believe we made it this far.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Then we make the best of it.
+JORDAN: I just pretend I'm in control.
+JORDAN: I can't believe we made it this far.
+JORDAN: Maybe control is just an illusion.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: And you were always the realist.
+ALEX: You always were the dreamer.
+ALEX: I just pretend I'm in control.
+ALEX: Then we make the best of it.
+ALEX: Maybe control is just an illusion.
+ALEX: I can't believe we made it this far.
+ALEX: I can't believe we made it this far.
+ALEX: Maybe control is just an illusion.
+ALEX: You're always so calm. How do you do it?
+JORDAN: What if this is all there is?
+JORDAN: Then we make the best of it.
+ALEX: What if this is all there is?
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: Always.
+ALEX: Do you hear that? The wind, it's calling us.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: I can't believe we made it this far.
+JORDAN: Do you ever think about what comes next?
+JORDAN: There's something in the air, a tension we can't ignore.
+JORDAN: You always were the dreamer.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: One last time. Are you with me?
+JORDAN: I just pretend I'm in control.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+JORDAN: One last time. Are you with me?
+JORDAN: One last time. Are you with me?
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: You're always so calm. How do you do it?
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: If we don't find a way out, this might be the end.
+JORDAN: If we don't find a way out, this might be the end.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: I can't believe we made it this far.
+ALEX: One last time. Are you with me?
+JORDAN: Maybe. But it's an illusion we need to survive.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Do you hear that? The wind, it's calling us.
+JORDAN: There's something in the air, a tension we can't ignore.
+ALEX: Sometimes, I wonder if we were meant for something greater.
+ALEX: It's too late for regrets now.
+ALEX: You always were the dreamer.
+ALEX: If we don't find a way out, this might be the end.
+ALEX: Then we make the best of it.
+JORDAN: The sky looks different tonight.
+ALEX: You always were the dreamer.
+ALEX: Maybe. But it's an illusion we need to survive.
+JORDAN: Then let's make sure the end is worth remembering.
+ALEX: There's something in the air, a tension we can't ignore.
+JORDAN: What if this is all there is?
+ALEX: Maybe control is just an illusion.
+ALEX: Maybe. But it's an illusion we need to survive.
+ALEX: What if this is all there is?
+JORDAN: It's too late for regrets now.
+ALEX: The sky looks different tonight.
+ALEX: It's too late for regrets now.
+JORDAN: I can't believe we made it this far.
+JORDAN: Do you ever think about what comes next?
+ALEX: I just pretend I'm in control.
+JORDAN: Sometimes, I wonder if we were meant for something greater.
+JORDAN: Maybe control is just an illusion.
+ALEX: We should have left when we had the chance.
+JORDAN: I just pretend I'm in control.
+JORDAN: We should have left when we had the chance.
+JORDAN: The sky looks different tonight.
+ALEX: If we don't find a way out, this might be the end.
+JORDAN: We should have left when we had the chance.
+ALEX: Then we make the best of it.
+ALEX: I just pretend I'm in control.


### PR DESCRIPTION
DeepInfra has a different error response when the context length is exceeded. This makes the map responses from the DeepInfra API to the equivalent exceptions that a call to OpenAI would return.